### PR TITLE
es6-ify some of the code for #1

### DIFF
--- a/01_Globals/main.js
+++ b/01_Globals/main.js
@@ -1,5 +1,5 @@
 // Main driver
-let nums = [1, 2, 3, 4, 5];
-let result = sum(nums);
+const nums = [1, 2, 3, 4, 5];
+const result = sum(nums);
 
 document.getElementById('output').innerHTML = result;

--- a/02_Namespaced_Modules/add.js
+++ b/02_Namespaced_Modules/add.js
@@ -1,4 +1,3 @@
 // Add module
-Utils.add = function add(a, b) {
-  return a + b;
-}
+Utils.add = (a, b) => a + b;
+

--- a/02_Namespaced_Modules/main.js
+++ b/02_Namespaced_Modules/main.js
@@ -3,8 +3,8 @@
 // are thrown in the function's closure and not
 // the global scope
 (function() {
-  let nums = [1, 2, 3, 4, 5];
-  let result = Utils.sum(nums);
+  const nums = [1, 2, 3, 4, 5];
+  const result = Utils.sum(nums);
 
   document.getElementById('output').innerHTML = result;
 }());

--- a/02_Namespaced_Modules/reduce.js
+++ b/02_Namespaced_Modules/reduce.js
@@ -1,6 +1,6 @@
 // Reduce module
 // Reduces a list given an operation and base value
-Utils.reduce = function reduce(list, op, base) {
+Utils.reduce = (list, op, base) => {
   list.forEach(item => {
     base = op(item, base);
   });

--- a/02_Namespaced_Modules/sum.js
+++ b/02_Namespaced_Modules/sum.js
@@ -1,4 +1,4 @@
 // Sum module depends on add + reduce modules
-Utils.sum = function sum(list) {
+Utils.sum = list => {
   return Utils.reduce(list, Utils.add, 0);
 }

--- a/03_CommonJS/main-production.js
+++ b/03_CommonJS/main-production.js
@@ -14,8 +14,8 @@ module.exports = add;
 const sum = require('./sum');
 
 (function() {
-  let nums = [1, 2, 3, 4, 5];
-  let result = sum(nums);
+  const nums = [1, 2, 3, 4, 5];
+  const result = sum(nums);
 
   document.getElementById('output').innerHTML = result;
 }());

--- a/03_CommonJS/main.js
+++ b/03_CommonJS/main.js
@@ -5,8 +5,8 @@
 const sum = require('./sum');
 
 (function() {
-  let nums = [1, 2, 3, 4, 5];
-  let result = sum(nums);
+  const nums = [1, 2, 3, 4, 5];
+  const result = sum(nums);
 
   document.getElementById('output').innerHTML = result;
 }());

--- a/04_AMD_RequireJS/README.md
+++ b/04_AMD_RequireJS/README.md
@@ -19,10 +19,8 @@ To define a module, we use the `define()` function whose API is above. `moduleId
 
 ```js
 // add.js
-define([], function() {
-  return function add(a, b) {
-    return a + b;
-  }
+define([], () => {
+  return (a, b) => a + b;
 });
 ```
 
@@ -32,10 +30,8 @@ Above we've created an anonymous module with no dependencies inside `add.js`. Es
 // sum.js
 
 // the sum module depends on reduce and add modules
-define(['./add', './reduce'], function(add, reduce) {
-  return function sum(list) {
-    return reduce(list, add, 0);
-  }
+define(['./add', './reduce'], (add, reduce) => {
+  return (list) => reduce(list, add, 0);
 });
 ```
 
@@ -46,12 +42,12 @@ In the above module we return a function that takes in a list and returns the su
 Consider the following AMD module:
 
 ```js
-define(['./sum'], function(sum) {
-  let nums = [1, 2, 3, 4, 5];
-  let result = sum(nums);
+define(['./sum'], sum => {
+  const nums = [1, 2, 3, 4, 5];
+  const result = sum(nums);
 
   if (/* perhaps some routing condition here for our app? */) {
-    require(['jquery'], function($) {
+    require(['jquery'], $ => {
       /**
        * Obviously we don't need to define a new module inside our
        * module, but we do want to `require` jquery asynchronously

--- a/04_AMD_RequireJS/add.js
+++ b/04_AMD_RequireJS/add.js
@@ -1,6 +1,4 @@
 // Add module
 define([], function() {
-  return function add(a, b) {
-    return a + b;
-  }
+  return (a, b) => a + b;
 });

--- a/04_AMD_RequireJS/main.js
+++ b/04_AMD_RequireJS/main.js
@@ -1,12 +1,12 @@
 // Main driver
 
 // Might use `require` here to kick off our app
-require(['./sum', 'jquery'], function(sum, $) {
+require(['./sum', 'jquery'], (sum, $) => {
   console.log('Cool, jQuery (', $, ') was loaded asynchronously before we got here');
-  let nums = [1, 2, 3, 4, 5];
-  let result = sum(nums);
+  const nums = [1, 2, 3, 4, 5];
+  const result = sum(nums);
 
-  require(['jquery'], function($) {
+  require(['jquery'], $ => {
     console.log('Since we\'ve already loaded $ one time here, RequireJS',
       'knows we do not need to re-fetch it from the CDN and refrains from',
       'making subsequent requests. Check the network tab!'

--- a/04_AMD_RequireJS/reduce.js
+++ b/04_AMD_RequireJS/reduce.js
@@ -1,7 +1,7 @@
 // Reduce module
 // Reduces a list given an operation and base value
 define([], function() {
-  return function reduce(list, op, base) {
+  return (list, op, base) => {
     list.forEach(item => {
       base = op(item, base);
     });

--- a/04_AMD_RequireJS/sum.js
+++ b/04_AMD_RequireJS/sum.js
@@ -1,14 +1,12 @@
 // Sum module depends on add + reduce modules
-define(['./add', './reduce'], function(add, reduce) {
+define(['./add', './reduce'], (add, reduce) => {
 
-  require(['jquery'], function($) {
+  require(['jquery'], $ => {
     console.log('At this point we have already asked RequireJS for the',
       'jquery dependency, so when we ask for it in here, it will know it',
       'does not need to re-fetch from the CDN. Check the network tab!'
     );
   });
 
-  return function sum(list) {
-    return reduce(list, add, 0);
-  }
+  return list => reduce(list, add, 0);
 });

--- a/05_Modules_With_Webpack/README.md
+++ b/05_Modules_With_Webpack/README.md
@@ -33,7 +33,7 @@ require.ensure(['async-module-a', 'async-module-b'], function(require) {
 
 ```js
 // Nothing new here
-define(['sync-module-here'], function(syncModule) {
+define(['sync-module-here'], syncModule => {
 
   // When webpack comes across this require call, it creates a separate bundle for the modules
   require(['async-module-a', 'async-module-b'], function(asyncModuleA, asyncModuleB) {

--- a/05_Modules_With_Webpack/add.js
+++ b/05_Modules_With_Webpack/add.js
@@ -1,6 +1,4 @@
 // Add moduls
-define([], function() {
-  return function add(a, b) {
-    return a + b;
-  }
+define([], () => {
+  return (a, b) => a + b;
 });

--- a/05_Modules_With_Webpack/entry.js
+++ b/05_Modules_With_Webpack/entry.js
@@ -4,14 +4,14 @@ document.getElementById('async-trigger').addEventListener('click', e => {
   console.log('Fetching JSON content and AMD add module asynchronously');
 
   // Require content asynchronously (see webpack.config.js)
-  require.ensure(['file!img!./500.jpg'], function(require) {
+  require.ensure(['file!img!./500.jpg'], function (require) {
     document.getElementById('async-img').src = require('file!img!./500.jpg');
   });
 
   // Require the add module asynchronously
   require(['./sum'], function (sum) {
-    let nums = [1, 2, 3, 4, 5];
-    let result = sum(nums);
+    const nums = [1, 2, 3, 4, 5];
+    const result = sum(nums);
 
     document.getElementById('async-output').innerHTML = result;
   });

--- a/05_Modules_With_Webpack/reduce.js
+++ b/05_Modules_With_Webpack/reduce.js
@@ -1,7 +1,7 @@
 // Reduce module
 // Reduces a list given an operation and base value
-define([], function() {
-  return function reduce(list, op, base) {
+define([], () => {
+  return (list, op, base) => {
     list.forEach(item => {
       base = op(item, base);
     });

--- a/05_Modules_With_Webpack/sum.js
+++ b/05_Modules_With_Webpack/sum.js
@@ -1,6 +1,4 @@
 // Sum module depends on add + reduce modules
-define(['./add', './reduce'], function(add, reduce) {
-  return function sum(list) {
-    return reduce(list, add, 0);
-  }
+define(['./add', './reduce'], (add, reduce) => {
+  return list => reduce(list, add, 0);
 });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Demonstrating different JavaScript module formats (CommonJS, AMD, ES2015, etc)",
   "main": "index.js",
   "scripts": {
+    "dev": "webpack-dev-server",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This is for https://github.com/domfarolino/modular-javascript/issues/1

The only things that could really be altered here was to add a bunch of arrow functions and a couple of variable declarations changed from `let` to `const` seeing as they are never modified.

In some cases I didn't add in arrow functions as I felt it made the code less clear. As an example:

``` js
define([], () => {
  return (a, b) => a + b;
});

```

is more readable than
define([], () => (a, b) => a + b);

``` js

```

(I think) so I left part of that alone.
